### PR TITLE
New module: Core general settings

### DIFF
--- a/src/actions/apply-presets.php
+++ b/src/actions/apply-presets.php
@@ -4,9 +4,15 @@ require_once plugin_dir_path( __FILE__ ) . 'core/user.php';
 require_once plugin_dir_path( __FILE__ ) . 'core/general-settings.php';
 require_once plugin_dir_path( __FILE__ ) . 'core/plugins.php';
 
-function get_presets_meta( $prefix, $field ) {
+function get_presets_meta( $prefix = null, $field = null ) {
 	$preset_id = filter_var( $_GET['presets-trigger'], FILTER_SANITIZE_NUMBER_INT );
-	return get_post_meta( $preset_id, 'presets_' . $prefix . $field, true );
+
+	if ( isset( $prefix ) ) {
+		return get_post_meta( $preset_id, 'presets_' . $prefix . $field, true );
+	} else {
+		return get_post_meta( $preset_id );
+	}
+
 }
 
 function apply_presets() {
@@ -66,7 +72,7 @@ function presets_admin_notice__success() {
 	?>
 		<div class="notice notice-success is-dismissible">
 			<p><?php _e( 'The settings were applied as expected! ' ); ?></p>
-			<?php var_dump( get_post( $_GET['presets-applied'] ) ); ?>
+			<?php var_dump( get_post_meta( $_GET['presets-applied'] ) ); ?>
 		</div>
 	<?php
 }

--- a/src/actions/apply-presets.php
+++ b/src/actions/apply-presets.php
@@ -72,7 +72,6 @@ function presets_admin_notice__success() {
 	?>
 		<div class="notice notice-success is-dismissible">
 			<p><?php _e( 'The settings were applied as expected! ' ); ?></p>
-			<?php var_dump( get_post_meta( $_GET['presets-applied'] ) ); ?>
 		</div>
 	<?php
 }

--- a/src/actions/apply-presets.php
+++ b/src/actions/apply-presets.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once plugin_dir_path( __FILE__ ) . 'core/user.php';
+require_once plugin_dir_path( __FILE__ ) . 'core/general-settings.php';
 require_once plugin_dir_path( __FILE__ ) . 'core/plugins.php';
 
 function get_presets_meta( $prefix, $field ) {
@@ -25,6 +26,7 @@ function apply_presets() {
 	 *
 	 * @hooked presets_core_user_apply_meta
 	 * @hooked presets_core_plugins_apply_meta
+	 * @hooked presets_core_general_settings_apply_meta
 	 */
 	do_action( 'presets_apply_meta' );
 
@@ -63,7 +65,8 @@ function presets_admin_notice__success() {
 
 	?>
 		<div class="notice notice-success is-dismissible">
-			<p><?php _e( 'The settings were applied as expected! ', 'presets' ); ?></p>
+			<p><?php _e( 'The settings were applied as expected! ' ); ?></p>
+			<?php var_dump( get_post( $_GET['presets-applied'] ) ); ?>
 		</div>
 	<?php
 }

--- a/src/actions/core/general-settings.php
+++ b/src/actions/core/general-settings.php
@@ -1,0 +1,32 @@
+<?php
+
+function presets_core_general_settings_apply_meta() {
+
+	$prefix = 'core_general_settings_';
+
+	$fields = array(
+		'blogname',
+		'blogdescription',
+		'admin_email',
+		'users_can_register',
+		'WPLANG',
+	);
+
+	function testing() {
+		return 'pt_br';
+	}
+
+	foreach ( $fields as $field ) {
+
+		$meta = get_presets_meta( $prefix, $field );
+
+		if ( ! empty( $meta ) ) {
+
+			update_option( $field, $meta );
+
+		}
+	}
+
+}
+
+add_action( 'presets_apply_meta', 'presets_core_general_settings_apply_meta' );

--- a/src/actions/core/general-settings.php
+++ b/src/actions/core/general-settings.php
@@ -25,8 +25,15 @@ function presets_core_general_settings_apply_meta() {
 
 			}
 
-			update_option( $field, $meta );
+			if ( 'en_US' === $meta && 'WPLANG' === $field ) {
 
+				update_option( $field, '' );
+
+			} else {
+
+				update_option( $field, $meta );
+
+			}
 		}
 	}
 

--- a/src/actions/core/general-settings.php
+++ b/src/actions/core/general-settings.php
@@ -12,15 +12,18 @@ function presets_core_general_settings_apply_meta() {
 		'WPLANG',
 	);
 
-	function testing() {
-		return 'pt_br';
-	}
-
 	foreach ( $fields as $field ) {
 
 		$meta = get_presets_meta( $prefix, $field );
 
-		if ( ! empty( $meta ) ) {
+		if ( array_key_exists( 'presets_' . $prefix . $field, get_presets_meta() ) ) {
+
+			// Download the lang pack first if the site language is not yet installed.
+			if ( 'WPLANG' === $field ) {
+
+				wp_download_language_pack( $meta );
+
+			}
 
 			update_option( $field, $meta );
 

--- a/src/metabox/core/general-settings.php
+++ b/src/metabox/core/general-settings.php
@@ -8,6 +8,8 @@ function presets_core_general_settings_language_options() {
 
 	$options = array();
 
+	$options['en_US'] = 'Default - English (United States)';
+
 	foreach ( $translations as $translation_id => $translation_meta ) {
 
 		$options[ $translation_id ] = $translation_meta['english_name'];

--- a/src/metabox/core/general-settings.php
+++ b/src/metabox/core/general-settings.php
@@ -1,0 +1,90 @@
+<?php
+
+function presets_core_general_settings_language_options() {
+
+	require_once ABSPATH . 'wp-admin/includes/translation-install.php';
+
+	$translations = wp_get_available_translations();
+
+	$options = array();
+
+	foreach ( $translations as $translation_id => $translation_meta ) {
+
+		$options[ $translation_id ] = $translation_meta['english_name'];
+
+	}
+
+	return $options;
+}
+
+function presets_core_general_settings_metabox() {
+
+	$prefix_meta = 'presets_core_general_settings_';
+
+	/**
+	 * Initiate the metabox
+	 */
+	$cmb = new_cmb2_box(
+		array(
+			'id'           => $prefix_meta . 'metabox',
+			'title'        => __( '[Core] General Settings', 'presets' ),
+			'object_types' => array( 'presets' ), // Post type
+			'context'      => 'normal',
+			'priority'     => 'high',
+			'show_names'   => true, // Show field names on the left
+		// 'cmb_styles' => false, // false to disable the CMB stylesheet
+		// 'closed'     => true, // Keep the metabox closed by default
+		)
+	);
+
+	$cmb->add_field(
+		array(
+			'name' => __( 'Site Title', 'presets' ),
+			'id'   => $prefix_meta . 'blogname',
+			'type' => 'text',
+		)
+	);
+
+	$cmb->add_field(
+		array(
+			'name' => __( 'Tagline', 'presets' ),
+			'id'   => $prefix_meta . 'blogdescription',
+			'type' => 'text',
+		)
+	);
+
+	$cmb->add_field(
+		array(
+			'name' => __( 'Administration Email Address', 'presets' ),
+			'id'   => $prefix_meta . 'admin_email',
+			'type' => 'text_email',
+		)
+	);
+
+	$cmb->add_field(
+		array(
+			'name'             => __( 'Anyone can register', 'presets' ),
+			'id'               => $prefix_meta . 'users_can_register',
+			'type'             => 'select',
+			'show_option_none' => ' ',
+			'default'          => 'custom',
+			'options'          => array(
+				0 => __( 'No', 'presets' ),
+				1 => __( 'Yes', 'presets' ),
+			),
+		)
+	);
+
+	$cmb->add_field(
+		array(
+			'name'             => __( 'Site Language', 'presets' ),
+			'id'               => $prefix_meta . 'WPLANG',
+			'type'             => 'select',
+			'show_option_none' => ' ',
+			'default'          => 'custom',
+			'options'          => presets_core_general_settings_language_options(),
+		)
+	);
+}
+
+add_action( 'presets_create_metabox', 'presets_core_general_settings_metabox' );

--- a/src/metabox/presets-options.php
+++ b/src/metabox/presets-options.php
@@ -9,6 +9,7 @@ if ( file_exists( dirname( __FILE__ ) . '/../../vendors/cmb2/init.php' ) ) {
 
 
 include_once plugin_dir_path( __FILE__ ) . 'core/user.php';
+include_once plugin_dir_path( __FILE__ ) . 'core/general-settings.php';
 include_once plugin_dir_path( __FILE__ ) . 'core/plugins.php';
 
 /**
@@ -22,6 +23,7 @@ function presets_options() {
 	 * presets_create_metabox hook.
 	 *
 	 * @hooked presets_core_user_create_metabox
+	 * @hooked presets_core_general_settings_metabox
 	 * @hooked presets_core_plugins_create_metabox
 	 */
 	do_action( 'presets_create_metabox' );


### PR DESCRIPTION
Added some fields from General Settings fields on a new core metabox.

It allows to change the following core options: 'Site Title', 'Tagline', 'Administration Email Address', 'Anyone can register', and 'Site Language'.